### PR TITLE
Request.js resultData treated as stream

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -29,9 +29,13 @@ Request.prototype.executeRequest= function(method, arguments, callback) {
 
 	https.get({ 'host': this.host, 'path': this.baseUrl+method+argumentString }, function(res) {
 		if ( res.statusCode && res.statusCode === 200 ) {
+		  var chunks="";
 			res.on('data', function(resultData) {
-				callback(null, JSON.parse(resultData));
+				chunks+=resultData;
 			});
+			res.on('end', function() {
+				callback(null, JSON.parse(chunks));
+	      		});
 		} else {
 			callback({code: res.StatusCode});
 		}


### PR DESCRIPTION
I've treated the resultData as a stream so it adds up and fires the callback on end , when there's no more data arriving in the stream.
JSON parse was throwing an error if the data was a chunk that was not a valid JSON.
