### PR TITLE
Fix two issues

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -36,10 +36,10 @@ Request.prototype.executeRequest = function(method, parameters, callback) {
           callback({
             message: body.error,
             code: body.responseCode
-          });
+          }, null);
+        } else {
+          callback(null, body)
         }
-
-        callback(null, body);
       });
     }
   ).on('error', function(error) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -35,7 +35,7 @@ Request.prototype.executeRequest = function(method, parameters, callback) {
         if (body.error) {
           callback({
             message: body.error,
-            code: body.responseCode
+            code: body.status
           }, null);
         } else {
           callback(null, body)


### PR DESCRIPTION
1. callback will fire twice if we have error response, the first one has (error, null) as input, and the second has a (null, results) as input but results is the same as error in the first one.
2. within a error response, responseCode has changed name to status.

Note: tested on consumer_key based api with 'Consumer key missing.' error.
